### PR TITLE
Job history review

### DIFF
--- a/src/job-client.js
+++ b/src/job-client.js
@@ -26,7 +26,7 @@ class JobClient{
      * @param {string} access_key - Identifier of the access key to be assigned to the user
      * @param {(Date|string)} start_date - initial date to filter recods
      * @param {(Date|string)} end_date - final date to filter recods
-     * @param {(string|string[])} job_identifiers - Array of unique job identifiers
+     * @param {string} model - model name or version
      * @param {string} status - Status of the jobs (all, pending, terminated)
      * @param {string} sortBy - attribute name to sort results
      * @param {string} direction - Direction of the sorting algorithm (asc, desc)
@@ -36,7 +36,7 @@ class JobClient{
 	 * @throws {ApiError} Error if there is something wrong with the service or the call
 	 */
 	getJobHistory(user, accessKey, startDate, endDate,
-                  jobIdentifiers, status,
+                  model, status,
                   page, perPage=1000, direction, sortBy
         ){
         if( user !== null && typeof user !== "string" ){
@@ -46,7 +46,7 @@ class JobClient{
             throw("the accessKey param should be a string");
         }  
         if( startDate !== null && startDate !== undefined ){
-            if( typeof startDate === "Date" ){
+            if( startDate instanceof Date ){
                 startDate = startDate.toISOString();
             }
             else if( typeof startDate !== "string" ){
@@ -64,9 +64,9 @@ class JobClient{
         if( status !== null && typeof status !== "string" ){
             throw("the status param should be a string");
         } 
-        if(jobIdentifiers !== null && jobIdentifiers.length !== undefined ){
-            throw("the jobIdentifiers param should be a array");
-        }
+        if( model !== null && typeof model !== "string" ){
+            throw("the model param should be a string");
+        } 
         if( sortBy !== null && typeof sortBy !== "string" ){
             throw("the sortBy param should be a string");
         }
@@ -84,7 +84,7 @@ class JobClient{
             "accessKey": accessKey,
             "startDate": startDate,
             "endDate": endDate,
-            "jobIdentifiers": jobIdentifiers,
+            "model": model,
             "status": status,
             "sort-by": sortBy,
             "direction": direction,

--- a/tests/job-client.test.js
+++ b/tests/job-client.test.js
@@ -6,77 +6,6 @@ import JobClient from '../src/job-client.js';
 const jobClient = new JobClient(process.env.MODZY_BASE_URL, process.env.MODZY_API_KEY);
 
 test(
-    'testGetJobHistoryStatusAll',
-    async () => {
-        await jobClient.getJobHistory(null, null, null, null, null, 'all', null, null, null, null)
-            .then(
-                (jobs) => {                    
-                    expect(jobs).toBeDefined();
-                    expect(jobs).not.toHaveLength(0);
-                    logger.info( `testGetJobHistoryStatusAll() get ${jobs.length} jobs` );
-                    jobs.forEach(
-                        (job)=>{                                                      
-                            expect(job.jobIdentifier).toBeDefined();
-                            expect(job.status).toBeDefined();
-                            expect(job.submittedAt).toBeDefined();
-                            expect(job.submittedBy).toBeDefined(); 
-                        }
-                    );
-                }
-            );
-    }
-);
-
-test(
-    'testGetJobHistoryByUser',
-    async () => {
-        await jobClient.getJobHistory(process.env.MODZY_API_KEY.substring(0,process.env.MODZY_API_KEY.lastIndexOf('.')), null, null, null, null, 'all', null, null, null, null)
-            .then(
-                (jobs) => {                    
-                    expect(jobs).toBeDefined();
-                    expect(jobs).not.toHaveLength(0);
-                    logger.info( `testGetJobHistoryByUser() get ${jobs.length} jobs` );
-                    jobs.forEach(
-                        (job)=>{                                                                              
-                            expect(job.jobIdentifier).toBeDefined();
-                            expect(job.status).toBeDefined();
-                            expect(job.submittedAt).toBeDefined();
-                            expect(job.submittedBy).toBeDefined();                            
-                        }
-                    );
-                }
-            );
-    }
-);
-
-test(
-    'testGetJobHistoryByAccessKey',
-    async () => {
-        await jobClient.getJobHistory(null, process.env.MODZY_API_KEY.substring(0,process.env.MODZY_API_KEY.lastIndexOf('.')), null, null, null, null, null, null, null, null)
-            .then(
-                (jobs) => {                    
-                    expect(jobs).toBeDefined();
-                    expect(jobs).not.toHaveLength(0);
-                    logger.info( `testGetJobHistoryByAccessKey() get ${jobs.length} jobs` );
-                    jobs.forEach(
-                        (job)=>{                                                      
-                            expect(job.jobIdentifier).toBeDefined();
-                            expect(job.status).toBeDefined();
-                            expect(job.submittedAt).toBeDefined();
-                            expect(job.submittedBy).toBeDefined();                            
-                        }
-                    );
-                }
-            )
-            .catch(
-                (error)=>{
-                    logger.error("Error: "+error);
-                }
-            );
-    }
-);
-
-test(
     'testSubmitJob',
     async () => {
         await jobClient.submitJob(
@@ -206,5 +135,128 @@ test(
             );
     }
 );
+
+test(
+    'testGetJobHistoryByUser',
+    async () => {
+        await jobClient.getJobHistory("a", null, null, null, null, null, null, null, null, null)
+            .then(
+                (jobs) => {
+                    expect(jobs).toBeDefined();
+                    expect(jobs).not.toHaveLength(0);
+                    logger.info( `testGetJobHistorybyUser() get ${jobs.length} jobs` );
+                    jobs.forEach(
+                        (job)=>{                                                      
+                            expect(job.jobIdentifier).toBeDefined();
+                            expect(job.status).toBeDefined();
+                            expect(job.submittedAt).toBeDefined();
+                            expect(job.submittedBy).toBeDefined(); 
+                        }
+                    );
+                }
+            );
+    }
+);
+
+test(
+    'testGetJobHistoryByModel',
+    async () => {
+        await jobClient.getJobHistory(null, null, null, null, "Sentiment Analysis", null, null, null, null, null)
+            .then(
+                (jobs) => {
+                    expect(jobs).toBeDefined();
+                    expect(jobs).not.toHaveLength(0);
+                    logger.info( `testGetJobHistoryByModel() get ${jobs.length} jobs` );
+                    jobs.forEach(
+                        (job)=>{                                                      
+                            expect(job.jobIdentifier).toBeDefined();
+                            expect(job.status).toBeDefined();
+                            expect(job.submittedAt).toBeDefined();
+                            expect(job.submittedBy).toBeDefined(); 
+                        }
+                    );
+                }
+            );
+    }
+);
+
+test(
+    'testGetJobHistoryByAccessKey',
+    async () => {
+        await jobClient.getJobHistory(null, process.env.MODZY_API_KEY.substring(0,process.env.MODZY_API_KEY.lastIndexOf('.')), null, null, null, null, null, null, null, null)
+            .then(
+                (jobs) => {                    
+                    expect(jobs).toBeDefined();
+                    expect(jobs).not.toHaveLength(0);
+                    logger.info( `testGetJobHistoryByAccessKey() get ${jobs.length} jobs` );
+                    jobs.forEach(
+                        (job)=>{                                                      
+                            expect(job.jobIdentifier).toBeDefined();
+                            expect(job.status).toBeDefined();
+                            expect(job.submittedAt).toBeDefined();
+                            expect(job.submittedBy).toBeDefined();                            
+                        }
+                    );
+                }
+            )
+            .catch(
+                (error)=>{
+                    logger.error("Error: "+error);
+                }
+            );
+    }
+);
+
+test(
+    'testGetJobHistoryByDate',
+    async () => {
+        let startDate = new Date();
+        startDate.setDate(startDate.getDate()-7);  
+        logger.info("StartDate type "+(startDate instanceof Date))      
+        await jobClient.getJobHistory(null, null, startDate, null, null, null, null, null, null, null)
+            .then(
+                (jobs) => {                    
+                    expect(jobs).toBeDefined();
+                    expect(jobs).not.toHaveLength(0);
+                    logger.info( `testGetJobHistoryByDate() get ${jobs.length} jobs` );
+                    jobs.forEach(
+                        (job)=>{                                                                              
+                            expect(job.jobIdentifier).toBeDefined();
+                            expect(job.status).toBeDefined();
+                            expect(job.submittedAt).toBeDefined();
+                            expect(job.submittedBy).toBeDefined();                            
+                        }
+                    );
+                }
+            );
+    }
+);
+
+test(
+    'testGetJobHistoryStatus',
+    async () => {
+        await jobClient.getJobHistory(null, null, null, null, null, 'terminated', null, null, null, null)
+            .then(
+                (jobs) => {
+                    expect(jobs).toBeDefined();
+                    expect(jobs).not.toHaveLength(0);
+                    logger.info( `testGetJobHistoryStatus() get ${jobs.length} jobs` );
+                    jobs.forEach(
+                        (job)=>{                                                      
+                            expect(job.jobIdentifier).toBeDefined();
+                            expect(job.status).toBeDefined();
+                            expect(job.submittedAt).toBeDefined();
+                            expect(job.submittedBy).toBeDefined(); 
+                        }
+                    );
+                }
+            );
+    }
+);
+
+
+
+
+
 
 


### PR DESCRIPTION
## Description

The SDK has some differences with the job-history-service defined [here](https://models.modzy.com/docs/api-reference/jobs/retrieve-job-history) as follows:

- **jobIdentifiers** is no longer supported
- **model** wasn't handled by the sdk

## Related issues

There are no issues reported

## Tests

job-client.test.js was updated according to the new params

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
