### PR TITLE
Support for input and output samples route

### DIFF
--- a/src/model-client.js
+++ b/src/model-client.js
@@ -278,7 +278,7 @@ class ModelClient{
 
     /**
 	 * 
-	 * Call the Modzy API Service that return a version list related to a model identifier
+	 * Call the Modzy API Service that return a model version
 	 * 
 	 * @param {string} modelId - Identifier of the model
      * @param {string} versionId - Identifier of the version
@@ -295,6 +295,64 @@ class ModelClient{
         .then(
             ( response )=>{
                 logger.info(`getModelVersion(${modelId}, ${versionId}) :: ${response.status} ${response.statusText}`);
+                return response.data;
+            }
+        )
+        .catch(
+            ( error )=>{                
+                throw( new ApiError( error ) );
+            }
+        );
+    }
+
+    /**
+	 * 
+	 * Call the Modzy API Service that return the model version input sample
+	 * 
+	 * @param {string} modelId - Identifier of the model
+     * @param {string} versionId - Identifier of the version
+	 * @return {String} A json string with the input sample
+	 * @throws {ApiError} Error if there is something wrong with the service or the call
+	 */
+    getModelVersionInputSample(modelId, versionId){
+        const requestURL = `${this.baseURL}/${modelId}/versions/${versionId}/sample-input`;
+        logger.debug(`getModelVersionInputSample(${modelId}, ${versionId}) GET ${requestURL}`);
+        return axios.get(
+            requestURL,
+            {headers: {'Authorization':`ApiKey ${this.apiKey}`}}
+        )
+        .then(
+            ( response )=>{
+                logger.info(`getModelVersionInputSample(${modelId}, ${versionId}) :: ${response.status} ${response.statusText}`);
+                return response.data;
+            }
+        )
+        .catch(
+            ( error )=>{                
+                throw( new ApiError( error ) );
+            }
+        );
+    }
+
+    /**
+	 * 
+	 * Call the Modzy API Service that return the model version output sample
+	 * 
+	 * @param {string} modelId - Identifier of the model
+     * @param {string} versionId - Identifier of the version
+	 * @return {String} A json string with the output sample
+	 * @throws {ApiError} Error if there is something wrong with the service or the call
+	 */
+    getModelVersionInputSample(modelId, versionId){
+        const requestURL = `${this.baseURL}/${modelId}/versions/${versionId}/sample-output`;
+        logger.debug(`getModelVersionOutputSample(${modelId}, ${versionId}) GET ${requestURL}`);
+        return axios.get(
+            requestURL,
+            {headers: {'Authorization':`ApiKey ${this.apiKey}`}}
+        )
+        .then(
+            ( response )=>{
+                logger.info(`getModelVersionOutputSample(${modelId}, ${versionId}) :: ${response.status} ${response.statusText}`);
                 return response.data;
             }
         )

--- a/tests/model-client.test.js
+++ b/tests/model-client.test.js
@@ -153,3 +153,55 @@ test(
             );
     }
 );
+
+test(
+    'testGetModelVersion',
+    async () => {        
+        await modelClient.getModelVersion('c60c8dbd79', '0.0.1')
+            .then(
+                (version) => {
+                    expect(version).toBeDefined();                    
+                    logger.info( `testGetModelVersion() get ${version.version} models` );                    
+                }
+            )
+            .catch(
+                (error)=>{
+                    logger.error("Error: "+error);
+                }
+            );
+    }
+);
+
+test(
+    'testGetModelVersionInputSample',
+    async () => {        
+        await modelClient.getModelVersionInputSample('c60c8dbd79', '0.0.1')
+            .then(
+                (inputSample) => {
+                    expect(inputSample).toBeDefined();                    
+                }
+            )
+            .catch(
+                (error)=>{
+                    logger.error("Error: "+error);
+                }
+            );
+    }
+);
+
+test(
+    'testGetModelVersionOutputSample',
+    async () => {        
+        await modelClient.getModelVersionOutputSample('c60c8dbd79', '0.0.1')
+            .then(
+                (outputSample) => {
+                    expect(outputSample).toBeDefined();                    
+                }
+            )
+            .catch(
+                (error)=>{
+                    logger.error("Error: "+error);
+                }
+            );
+    }
+);


### PR DESCRIPTION
## Description

Added support for: 

- model/{modelId}/versions/{version}/sample-input
- model/{modelId}/versions/{version}/sample-output

## Related issues

No issues related.

## Tests

- https://github.com/modzy/sdk-javascript/blob/7d9fa76f6f6f3a6a792faabb1e5b0173ab1c1f70/tests/model-client.test.js#L175-L190
- https://github.com/modzy/sdk-javascript/blob/7d9fa76f6f6f3a6a792faabb1e5b0173ab1c1f70/tests/model-client.test.js#L192-L207

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
