### PR TITLE
Fix: error handling when server disconnect

### DIFF
--- a/src/api-error.js
+++ b/src/api-error.js
@@ -15,8 +15,8 @@ class ApiError{
     constructor(error=null, url="", code=500, message="Unexpected"){
         this.error   = error !== null ? error.toJSON() : message;
         this.url     = error !== null ? this.error.config.url : url;
-        this.code    = error !== null ? ( error.response.data ? error.response.data.statusCode : this.data.code ) : code;
-        this.message = error !== null ? ( error.response.data ? error.response.data.message : this.error.message ) : message;
+        this.code    = error !== null ? ( error.response?.data ? error.response.data.statusCode : code ) : code;
+        this.message = error !== null ? ( error.response?.data ? error.response.data.message : this.error.message ) : message;
     }
 
     /**


### PR DESCRIPTION
## Description

When the connection with the server is broken we are showing a generic error trying to access the data item in the response, but that item is not there because we don't have a response,

## Related issues

Not related issues

## Tests

Just calling when is disconnected will improve the error message like this:

```
[2021-03-10T09:32:15.686] [WARN] modzy - Unexpected error 500 :: getaddrinfo ENOTFOUND modzy-url :: https://modzy-url/api/models/ed542963de
```

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
