### PR TITLE
Prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/modzy/sdk-javascript#readme",
   "scripts": {
-    "prepare": "babel src --out-dir=dist",
     "prepack": "babel src --out-dir=dist",
     "docs": "jsdoc -c jsdoc.json",
     "build": "babel src --out-dir=dist",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/modzy/sdk-javascript#readme",
   "scripts": {
     "prepare": "babel src --out-dir=dist",
+    "prepack": "babel src --out-dir=dist",
     "docs": "jsdoc -c jsdoc.json",
     "build": "babel src --out-dir=dist",
     "test": "jest --detectOpenHandles"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/modzy/sdk-javascript#readme",
   "scripts": {
+    "prepare": "babel src --out-dir=dist",
     "prepack": "babel src --out-dir=dist",
     "docs": "jsdoc -c jsdoc.json",
     "build": "babel src --out-dir=dist",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/modzy/sdk-javascript#readme",
   "scripts": {
+    "prepare": "babel src --out-dir=dist",
     "docs": "jsdoc -c jsdoc.json",
     "build": "babel src --out-dir=dist",
     "test": "jest --detectOpenHandles"


### PR DESCRIPTION
## Description

After review and test in a fresh install, I notice that we need to configure an npm or yarn standard lyfecicle hook in order to allow install from git works as expected.

## Related issues

We don't have any issues regarding this yet.

## Tests

* Create a new folder
* npm:
* * `npm init`
* * `npm add modzy/sdk-javascript#prepareScript`
* * Check the inner package installed `/node_modules/modzy-sdk/` (search for the dist folder)
* yarn:
* * `yarn init`
* * `yarn add modzy/sdk-javascript#prepareScript`
* * Check the inner package installed `/node_modules/modzy-sdk/` (search for the dist folder)

There are a few bugs documented regarding [yarn](https://github.com/yarnpkg/yarn/issues/5235#issuecomment-571206092), but until we deploy in some package manager we are fine.

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
